### PR TITLE
Replace bs4 with beautifulsoup4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ version = '0.1.8.1'
 
 REQUIREMENTS = [
     'requests',
-    'bs4',
+    'beautifulsoup4',
     'six'
 ]
 


### PR DESCRIPTION
Don't use [`bs4` dummy package](https://pypi.org/project/bs4/) as distributions don't ship it. They use `beautifulsoup4`.