### PR TITLE
Update license tag

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     version=version,
     packages=['incapsula'],
     url='https://github.com/ziplokk1/incapsula-cracker-py3',
-    license='LICENSE.txt',
+    license='Unlicense',
     author='Mark Sanders',
     author_email='sdscdeveloper@gmail.com',
     install_requires=REQUIREMENTS,


### PR DESCRIPTION
Allow third-party tools (e. g., PyPI or `pyp2rpm`) to get the license details in a simple way.